### PR TITLE
fix: allow to pass ip of nsmgr-proxy via env

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -30,7 +30,6 @@ import (
 	_ "google.golang.org/grpc"
 	_ "google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/health/grpc_health_v1"
-	_ "net"
 	_ "net/url"
 	_ "os"
 	_ "os/signal"


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

Related https://github.com/networkservicemesh/deployments-k8s/pull/1783


**Problem:**
The current version of nsmgr-proxy sets wrong IP for incoming NSE registration.

**Solution:**
1. Add hostNetwork for nsmgr-proxy and pass IP of the pod via IP env. 
2. Map nsmgr-proxy IP from internal to external via map-ip sidecar.